### PR TITLE
Made ARM recognition fault-tolerant

### DIFF
--- a/keypatch.py
+++ b/keypatch.py
@@ -99,7 +99,7 @@ class Keypatch_Asm:
             if info.is_64bit():
                 arch = KS_ARCH_ARM64
                 mode = KS_MODE_LITTLE_ENDIAN
-            elif info.is_32bit():
+            else:
                 arch = KS_ARCH_ARM
                 # either big-endian or little-endian
                 if cpuname == "arm":


### PR DESCRIPTION
I have some Cortex-M3 databases where idaapi.get_inf_structure().is_32bit()
returns false. The reason is unknown and can't be reproduced. These databases
have been created with versions < 6.8 of IDA.