### PR TITLE
Fix missing argument in idaapi.add_menu_item

### DIFF
--- a/keypatch.py
+++ b/keypatch.py
@@ -1166,7 +1166,7 @@ class Keypatch_Plugin_t(idaapi.plugin_t):
                 idaapi.add_menu_item("Edit/Patch program/", "Keypatch:: Check for update ...", "", 0, self.updater, None)
                 idaapi.add_menu_item("Edit/Patch program/", "Keypatch:: Assembler", "", 0, self.assembler, None)
                 idaapi.add_menu_item("Edit/Patch program/", "Keypatch:: Undo last patching", "", 0, self.undo, None)
-                idaapi.add_menu_item("Edit/Patch program/", "Keypatch:: Patcher     (Ctrl+Alt+K)", 0, self.patcher, None)
+                idaapi.add_menu_item("Edit/Patch program/", "Keypatch:: Patcher     (Ctrl+Alt+K)", "", 0, self.patcher, None)
 
             print("=" * 80)
             print("Keypatch registered IDA plugin {0} (c) Nguyen Anh Quynh & Thanh Nguyen, 2016".format(VERSION))


### PR DESCRIPTION
The missing argument causes keypatch loading to fail in the following condition:
1- start IDA and load any binary, keypatch starts fine
2- close the binary and open a new one. keypatch fails with:
Failed while executing plugin_t.init():
Traceback (most recent call last):
  File "<IDA>/plugins/keypatch.py", line 1169, in init
    idaapi.add_menu_item("Edit/Patch program/", "Keypatch:: Patcher     (Ctrl+Alt+K)", 0, self.patcher, None)
  File "<IDA>/python/ida_kernwin.py", line 332, in add_menu_item
    return _ida_kernwin.add_menu_item(*args)
TypeError: add_menu_item expected 6 arguments, got 5

This affects at least 6.9 and 6.95.